### PR TITLE
fix: 縦長画像の比較パネルをセンタリング (#20)

### DIFF
--- a/components/ImageComparison.tsx
+++ b/components/ImageComparison.tsx
@@ -154,6 +154,8 @@ export default function ImageComparison({
     h: number
     left: number
     top: number
+    panelLeft: number
+    panelHeight: number
   } | null>(null)
 
   // --- Load both images as Image objects (no DOM <img>) ---
@@ -195,7 +197,7 @@ export default function ImageComparison({
     const ph = panel.clientHeight
     if (!pw || !ph) return
     const rect = computeImgRect(pw, ph, naturalSize.w, naturalSize.h)
-    setImgRect(rect)
+    setImgRect({ ...rect, panelLeft: panel.offsetLeft, panelHeight: ph })
     onDisplaySizeRef.current?.(rect)
   }, [naturalSize])
 
@@ -494,11 +496,11 @@ export default function ImageComparison({
     ? { x: imgRect.left + imgRect.w / 2, y: imgRect.top + imgRect.h / 2 }
     : null
 
-  const panelHeight = panelRef.current?.clientHeight ?? 0
-  // Panel can be narrower than its container (mx-auto centering for portrait images).
-  // Handles live in a sibling wrapper whose origin is the container's left edge, so shift
+  // Panel may be narrower than its shared parent (mx-auto centering for portrait images).
+  // Handles live in a sibling wrapper whose origin is the parent's left edge, so shift
   // them by the panel's left offset to stay aligned with the image content.
-  const panelLeft = panelRef.current?.offsetLeft ?? 0
+  const panelLeft = imgRect?.panelLeft ?? 0
+  const panelHeight = imgRect?.panelHeight ?? 0
 
   // Panel aspect ratio for sizing (replaces the DOM img element's sizing role)
   const panelAspectRatio = naturalSize ? `${naturalSize.w} / ${naturalSize.h}` : undefined

--- a/components/ImageComparison.tsx
+++ b/components/ImageComparison.tsx
@@ -495,6 +495,10 @@ export default function ImageComparison({
     : null
 
   const panelHeight = panelRef.current?.clientHeight ?? 0
+  // Panel can be narrower than its container (mx-auto centering for portrait images).
+  // Handles live in a sibling wrapper whose origin is the container's left edge, so shift
+  // them by the panel's left offset to stay aligned with the image content.
+  const panelLeft = panelRef.current?.offsetLeft ?? 0
 
   // Panel aspect ratio for sizing (replaces the DOM img element's sizing role)
   const panelAspectRatio = naturalSize ? `${naturalSize.w} / ${naturalSize.h}` : undefined
@@ -566,7 +570,7 @@ export default function ImageComparison({
       {/* Image panel — canvas renders both images, no DOM <img> */}
       <div
         ref={panelRef}
-        className="relative flex touch-none select-none items-center justify-center overflow-hidden"
+        className="relative mx-auto flex touch-none select-none items-center justify-center overflow-hidden"
         style={{
           borderRadius: 14,
           border: `2px solid ${activeColor}40`,
@@ -575,6 +579,9 @@ export default function ImageComparison({
           transition: 'border-color 0.2s ease',
           minHeight: 'min(280px, calc(100dvh - var(--panel-margin)))',
           maxHeight: 'calc(100dvh - var(--panel-margin))',
+          maxWidth: naturalSize
+            ? `calc((100dvh - var(--panel-margin)) * ${naturalSize.w} / ${naturalSize.h})`
+            : undefined,
           aspectRatio: panelAspectRatio,
           cursor: isDragging ? 'grabbing' : 'grab',
         }}
@@ -596,7 +603,7 @@ export default function ImageComparison({
               key={`corner-${i}`}
               className="absolute"
               style={{
-                left: pos.x + cornerOffsets[i].x + offset.x - HANDLE_HIT_RADIUS,
+                left: panelLeft + pos.x + cornerOffsets[i].x + offset.x - HANDLE_HIT_RADIUS,
                 top: pos.y + cornerOffsets[i].y + offset.y - HANDLE_HIT_RADIUS - panelHeight,
                 width: HANDLE_HIT_RADIUS * 2,
                 height: HANDLE_HIT_RADIUS * 2,
@@ -645,7 +652,7 @@ export default function ImageComparison({
             <div
               className="absolute"
               style={{
-                left: centerPosition.x + centerOffset.x + offset.x - HANDLE_HIT_RADIUS,
+                left: panelLeft + centerPosition.x + centerOffset.x + offset.x - HANDLE_HIT_RADIUS,
                 top: centerPosition.y + centerOffset.y + offset.y - HANDLE_HIT_RADIUS - panelHeight,
                 width: HANDLE_HIT_RADIUS * 2,
                 height: HANDLE_HIT_RADIUS * 2,


### PR DESCRIPTION
## 関連 Issue
closes #20

## 変更内容

- 比較ステップで正方形より縦長の画像を開くと、パネルが親の左に詰まって表示されていた
- パネルに `mx-auto` と `maxWidth: calc((100dvh - var(--panel-margin)) * w / h)` を追加し、縦長時は幅を画像アスペクトに絞って水平中央寄せ
- コーナー／中心ハンドルの `left` に `panelLeft`（= `panel.offsetLeft`）のシフトを追加してパネル中央寄せ後もハンドルが画像角に重なるよう修正
- 横長・正方形画像は従来通り（width 100%）

## 動作確認

- `npm run lint` / `npm run build` 通過
- dev server + Playwright (1280×720 viewport) で縦長画像（3472×4624）をアップロード→比較ステップで panel.left=527.5 / panel.width=225 / viewport center=640 となり水平中央寄せを確認
- コーナーハンドル4個の中心がパネル四隅に一致することを確認