### PR TITLE
fix: IDB 移行後の複合リグレッション (#23)

### DIFF
--- a/components/ImageComparison.tsx
+++ b/components/ImageComparison.tsx
@@ -582,7 +582,7 @@ export default function ImageComparison({
           minHeight: 'min(280px, calc(100dvh - var(--panel-margin)))',
           maxHeight: 'calc(100dvh - var(--panel-margin))',
           maxWidth: naturalSize
-            ? `calc((100dvh - var(--panel-margin)) * ${naturalSize.w} / ${naturalSize.h})`
+            ? `min(calc((100dvh - var(--panel-margin)) * ${naturalSize.w} / ${naturalSize.h}), 100%)`
             : undefined,
           aspectRatio: panelAspectRatio,
           cursor: isDragging ? 'grabbing' : 'grab',

--- a/components/ImageProcessor.tsx
+++ b/components/ImageProcessor.tsx
@@ -358,8 +358,15 @@ export default function ImageProcessor() {
     restoredCenterRef.current = null
 
     if (twoImageMode) {
-      // Go back to 2nd image corner adjustment (keep firstProcessedImage)
-      setSuggestedCorners(secondCornersRef.current ?? lastCornersRef.current)
+      // Restart from the 1st image corner adjustment. The 2nd image is still
+      // held in pendingSecondImageRef, so startSecondImageProcessing() will
+      // re-run automatically once the 1st corners are re-applied.
+      setProcessingSecondImage(false)
+      if (firstOriginalImageRef.current) setOriginalImage(firstOriginalImageRef.current)
+      if (firstImageSizeRef.current) setImageSize(firstImageSizeRef.current)
+      setSuggestedCorners(firstCornersRef.current ?? lastCornersRef.current)
+      setFirstProcessedImage(null)
+      secondCornersRef.current = null
     } else {
       setSuggestedCorners(lastCornersRef.current)
     }

--- a/components/ImageProcessor.tsx
+++ b/components/ImageProcessor.tsx
@@ -517,8 +517,8 @@ export default function ImageProcessor() {
         : originalImage
       const rightSource = twoImageMode ? pendingSecondImageRef.current : null
 
-      const originalBlob = dataUrlToBlob(leftSource)
-      const rightBlob = rightSource ? dataUrlToBlob(rightSource) : undefined
+      const originalBlob = await dataUrlToBlob(leftSource)
+      const rightBlob = rightSource ? await dataUrlToBlob(rightSource) : undefined
 
       const data: Omit<SaveEntry, 'id' | 'savedAt'> = {
         originalImage: originalBlob,

--- a/lib/image-utils.ts
+++ b/lib/image-utils.ts
@@ -12,9 +12,18 @@ const GIF_MAX_DIM = 480
 /** APNG download image max dimension (higher quality than GIF) */
 const APNG_MAX_DIM = 800
 
-/** Convert a base64 data URL to a Blob (CSP-friendly — no `fetch` on data: URLs). */
-export function dataUrlToBlob(dataUrl: string): Blob {
-  const [header, data] = dataUrl.split(',')
+/**
+ * Convert a URL (data: or blob:) to a Blob.
+ * - data: URLs use an atob-based fast path (CSP-friendly — no `fetch`).
+ * - blob: URLs fall through to `fetch` so restored saves (where the source
+ *   is an object URL backed by an IDB Blob) can be re-saved without errors.
+ */
+export async function dataUrlToBlob(url: string): Promise<Blob> {
+  if (url.startsWith('blob:')) {
+    const res = await fetch(url)
+    return await res.blob()
+  }
+  const [header, data] = url.split(',')
   const mimeMatch = header.match(/^data:([^;,]+)(?:;[^,]*?)?;base64$/i)
   if (!mimeMatch) throw new Error('Invalid data URL')
   const mime = mimeMatch[1]


### PR DESCRIPTION
## 関連 Issue
closes #23

## 変更内容

PR #21 (IndexedDB 移行) / PR #22 (パネル中央寄せ) 後のリグレッション修正:

### Bug 1: 横長画像がモバイル画面を突き抜ける
- `mx-auto` + `aspect-ratio` の shrink-to-fit が \`maxHeight × aspectRatio\` を採用してしまい、モバイルで親幅を超えていた
- panel `maxWidth` を \`min(calc(...), 100%)\` でクランプ

### Bug 2: 復元→再保存で「ほぞんできなかった」
- PR #21 で atob ベース化した `dataUrlToBlob` が \`blob:\` URL を受け付けず throw していた
- `dataUrlToBlob` を async に戻し、\`blob:\` URL は \`fetch\` フォールバック、\`data:\` URL は atob fast-path の併用へ

### Bug 3: 2枚モード保存→復元で左右が同じ
- Playwright 実機再現テストで **再現せず**。保存・復元とも IDB に別 Blob として正しく格納・読み出されていた
- Bug 2 の副作用（再保存失敗時に前のセッション表示のまま見える）で「両方同じ」と見えていた可能性が高い
- Bug 2 の修正で解消されるシナリオと判断。個別再現条件があれば追加調査予定

### Bug 4: 2枚モードで「角の調整にもどる」が1枚目に戻れない
- `handleBackToAdjust` を2枚モードのとき1枚目の state/refs に戻すよう変更
- \`processingSecondImage=false\`、\`originalImage=1枚目\`、\`firstProcessedImage=null\`、\`secondCornersRef=null\` にリセット
- 既存の `pendingSecondImageRef` が2枚目URLを保持しているため、1枚目適用後に自動で2枚目フローが走る

## 動作確認

Playwright で 390×844 モバイル viewport 実機確認:
- Bug 1: panel maxWidth computed=\`min(551.695px, 100%)\`、parentWidth=358 内に収まる
- Bug 2: 復元→再保存で saveFailed トーストなし、IDB に新 Blob 保存成功
- Bug 4: Back to corners で step=1 に戻り、OK→OK で result 到達

`npm run lint` / `npm run build` 通過。