### PR TITLE
fix: iOS版LINE案内の文言を実機挙動に合わせる (#29)

### DIFF
--- a/components/ImageUpload.tsx
+++ b/components/ImageUpload.tsx
@@ -310,7 +310,7 @@ export default function ImageUpload({
                 }}
               >
                 <p className="text-sm" style={{ color: 'var(--espresso)' }}>
-                  {t('lineInAppWarning')}
+                  {lineEnv === 'ios' ? t('lineInAppWarningIos') : t('lineInAppWarning')}
                 </p>
                 <button onClick={handleOpenExternal} className="btn-action px-4 py-2 text-sm">
                   {t('lineInAppOpenExternal')}

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -132,25 +132,29 @@ const dict = {
     ja: 'LINEアプリ内ではカメラが使えないことがあるよ',
     en: 'Camera may not work inside the LINE app',
   },
+  lineInAppWarningIos: {
+    ja: 'ふつうのブラウザで ひらくと、ホーム画面に おけて べんりだよ',
+    en: 'Open in your usual browser to add it to your home screen',
+  },
   lineInAppOpenExternal: {
     ja: '外部ブラウザで開く',
     en: 'Open in browser',
   },
   iosLineModalTitle: {
-    ja: 'Safariで開いてね',
-    en: 'Please open in Safari',
+    ja: 'ブラウザで開いてね',
+    en: 'Open in your browser',
   },
   iosLineModalDesc: {
-    ja: 'iPhoneのLINEからは カメラをつかうのが むずかしいんだ。\nしたの てじゅんで Safariで ひらいてね。',
-    en: "The LINE app on iPhone can't open the camera directly.\nFollow the steps below to open this page in Safari.",
+    ja: 'ふつうのブラウザで ひらくと、ホーム画面に おけて つぎから すぐ あそべるよ。\nしたの てじゅんで ひらいてね。',
+    en: 'Opening this in your usual browser lets you add it to your home screen for quick access next time.\nFollow the steps below.',
   },
   iosLineModalStep1: {
     ja: '右下の「・・・」メニューをタップ',
     en: "Tap the '...' menu in the bottom right",
   },
   iosLineModalStep2: {
-    ja: '「他のアプリで開く」または「Safariで開く」を選ぶ',
-    en: "Select 'Open in another app' or 'Open in Safari'",
+    ja: '「ブラウザで開く」を選ぶ',
+    en: "Select 'Open in browser'",
   },
   copyUrl: { ja: 'URLをコピー', en: 'Copy URL' },
   urlCopied: { ja: 'コピーしたよ', en: 'Copied!' },


### PR DESCRIPTION
## 関連 Issue
closes #29

## 変更内容

iOS版LINE内蔵ブラウザの実機検証で判明した文言ズレを修正。

- **iOS版LINEはカメラが使えた**（Androidより快適）。「カメラが使えない」という嘘を削除
- バナー文言を OS 別に分岐: iOS には新キー \`lineInAppWarningIos\` を追加し、PWA インストール推奨の案内に
- モーダルのステップ2を実機通りの「ブラウザで開く」表記に修正（旧: 「他のアプリで開く」「Safariで開く」）
- モーダルタイトル・説明文も「Safari限定」前提を外し、ホーム画面追加メリットの案内に変更
- ja / en 両方更新

## 受け入れ条件
- [x] iOS LINE で開いたとき、カメラ不可と書かれていない
- [x] iOS LINE モーダルのステップに「ブラウザで開く」が含まれる
- [x] Android LINE の文言は維持
- [x] ja / en 両方更新