### PR TITLE
fix: #28 #26 saving中スピナー表示・pendingSecondImageRef null ガード追加

### DIFF
--- a/components/ImageProcessor.tsx
+++ b/components/ImageProcessor.tsx
@@ -347,6 +347,17 @@ export default function ImageProcessor() {
     }
   }
 
+  /**
+   * 「角の調整にもどる」ボタンのハンドラ。
+   *
+   * 2枚モード時は pendingSecondImageRef.current に2枚目の data URL が
+   * 生存していることを前提とする。startSecondImageProcessing() は
+   * 1枚目のコーナーが再確定されたタイミングで自動的に再実行される。
+   *
+   * pendingSecondImageRef.current が null の場合（通常は起こりえないが
+   * 将来の変更で成功時に null 化された場合など）は handleReset() に
+   * フォールバックして整合性を保つ。
+   */
   const handleBackToAdjust = () => {
     setLeftImage(null)
     setRightImage(null)
@@ -358,6 +369,14 @@ export default function ImageProcessor() {
     restoredCenterRef.current = null
 
     if (twoImageMode) {
+      // Guard: pendingSecondImageRef must be alive for re-processing to work.
+      // If it has been cleared, fall back to a full reset rather than leaving
+      // the UI in a broken state.
+      if (!pendingSecondImageRef.current) {
+        showToast(t('restoreFailed'), 'error')
+        handleReset()
+        return
+      }
       // Restart from the 1st image corner adjustment. The 2nd image is still
       // held in pendingSecondImageRef, so startSecondImageProcessing() will
       // re-run automatically once the 1st corners are re-applied.
@@ -718,7 +737,23 @@ export default function ImageProcessor() {
               className="btn-ghost flex items-center gap-1.5 px-5 py-3 text-sm"
               style={saveSuccess ? { color: '#2d8a4e', borderColor: '#2d8a4e' } : undefined}
             >
-              {saveSuccess ? (
+              {saving ? (
+                <svg
+                  width={16}
+                  height={16}
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  aria-hidden="true"
+                  className="animate-spin opacity-50"
+                >
+                  <circle cx="12" cy="12" r="10" strokeOpacity="0.25" />
+                  <path d="M12 2a10 10 0 0 1 10 10" />
+                </svg>
+              ) : saveSuccess ? (
                 <svg
                   width={16}
                   height={16}

--- a/components/ImageProcessor.tsx
+++ b/components/ImageProcessor.tsx
@@ -372,6 +372,7 @@ export default function ImageProcessor() {
       // Guard: pendingSecondImageRef must be alive for re-processing to work.
       // If it has been cleared, fall back to a full reset rather than leaving
       // the UI in a broken state.
+      // NOTE: handleReset does NOT call handleBackToAdjust — no circular call.
       if (!pendingSecondImageRef.current) {
         showToast(t('restoreFailed'), 'error')
         handleReset()
@@ -738,17 +739,19 @@ export default function ImageProcessor() {
               style={saveSuccess ? { color: '#2d8a4e', borderColor: '#2d8a4e' } : undefined}
             >
               {saving ? (
+                // Spinner: use --muted (var(--muted)=#7a5c2e) per DESIGN.md secondary text role.
+                // Track ring at 25% opacity, arc at full opacity to form a classic spinner.
                 <svg
                   width={16}
                   height={16}
                   viewBox="0 0 24 24"
                   fill="none"
-                  stroke="currentColor"
+                  stroke="var(--muted)"
                   strokeWidth="2.5"
                   strokeLinecap="round"
                   strokeLinejoin="round"
                   aria-hidden="true"
-                  className="animate-spin opacity-50"
+                  className="animate-spin"
                 >
                   <circle cx="12" cy="12" r="10" strokeOpacity="0.25" />
                   <path d="M12 2a10 10 0 0 1 10 10" />

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,15 @@
 
 ### 修正 🐛
 
+- **「ほぞん」中の視覚フィードバックがない問題を修正** (#28)
+  - async 化後、保存処理中は `disabled` になるだけでスピナー等の表示がなく、ユーザーに「何も起きていない」ように見えた
+  - 修正: `saving === true` 中はボタンアイコンをグレーの回転スピナー SVG に切り替え（`animate-spin`）、既存の保存成功時チェックマークと同じ方式で実装
+
+- **`handleBackToAdjust` の `pendingSecondImageRef` null ガードを追加** (#26)
+  - 2枚モードで「かどの調整にもどる」を押したとき、`pendingSecondImageRef.current` が null だった場合のフォールバック処理がなく、将来の変更で即破綻するリスクがあった
+  - 修正: null の場合は `restoreFailed` トーストを表示して `handleReset()` にフォールバック
+  - あわせて `handleBackToAdjust` の JSDoc で `pendingSecondImageRef` の生存契約を明示
+
 - **比較ステップで縦長画像が左詰めになる問題を修正（パネル水平中央寄せ）** (#20)
   - 正方形より縦長の画像を開くと、パネルが親コンテナの左に詰まって表示されていた
   - panel に `mx-auto` と `maxWidth` 計算を追加して水平中央寄せ


### PR DESCRIPTION
## 関連 Issue
closes #28
closes #26

## 変更内容

### #28「ほぞん」中の視覚フィードバックがない（async 化後）
- `saving === true` 中はボタンアイコンをグレーの回転スピナー SVG に切り替え（Tailwind `animate-spin`）
- 既存の保存成功チェックマークと同じ方式で `saving → spinner` / `saveSuccess → check` / default → SaveIcon の3段構成に

### #26 handleBackToAdjust → pendingSecondImageRef 契約が脆い
- 2枚モード分岐で `pendingSecondImageRef.current` が null のとき `restoreFailed` トーストを表示して `handleReset()` にフォールバック
- `handleBackToAdjust` に JSDoc を追加し、`pendingSecondImageRef` の生存契約を明示