### PR TITLE
SEO土台整備: robots.txt / sitemap.xml / JSON-LD / description拡充 (#42)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,9 +6,26 @@ import './globals.css'
 
 const siteUrl = 'https://machigai-salad.llll-ll.com'
 
+// Longer, keyword-bearing description for search snippets. The on-page subtitle
+// stays short ('間違いさがし おたすけツール'); this is the search-facing copy.
+const description =
+  '2枚の画像を並べて拡大・比較できる間違い探しのおたすけツール。答え合わせやヒント探しに便利。インストール不要、ブラウザだけで動きます。'
+
 export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl),
   title: '小エビの間違いサラダ',
-  description: '間違いさがし おたすけツール',
+  description,
+  keywords: [
+    '間違い探し',
+    '間違いさがし',
+    'まちがいさがし',
+    '間違いサラダ',
+    '答え合わせ',
+    'ヒント',
+    '画像比較',
+    '拡大',
+    'ツール',
+  ],
   manifest: '/manifest.webmanifest',
   appleWebApp: {
     capable: true,
@@ -19,7 +36,7 @@ export const metadata: Metadata = {
     type: 'website',
     url: siteUrl,
     title: '小エビの間違いサラダ',
-    description: '間違いさがし おたすけツール',
+    description,
     siteName: '小エビの間違いサラダ',
     locale: 'ja_JP',
     images: [{ url: `${siteUrl}/static/ogp.webp`, width: 1200, height: 630 }],
@@ -27,12 +44,30 @@ export const metadata: Metadata = {
   twitter: {
     card: 'summary_large_image',
     title: '小エビの間違いサラダ',
-    description: '間違いさがし おたすけツール',
+    description,
     images: [`${siteUrl}/static/ogp.webp`],
   },
   icons: {
     icon: '/favicon.webp',
     apple: '/apple-touch-icon.webp',
+  },
+}
+
+// Structured data so search engines can render the tool as a SoftwareApplication
+// rich result. Free, browser-based, Japanese.
+const jsonLd = {
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareApplication',
+  name: '小エビの間違いサラダ',
+  url: siteUrl,
+  description,
+  applicationCategory: 'UtilitiesApplication',
+  operatingSystem: 'Web',
+  inLanguage: 'ja',
+  offers: {
+    '@type': 'Offer',
+    price: '0',
+    priceCurrency: 'JPY',
   },
 }
 
@@ -48,6 +83,10 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body className="antialiased">
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+        />
         <I18nProvider>
           {children}
           <ToastContainer />

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,18 @@
+import type { MetadataRoute } from 'next'
+
+// Canonical production deploy (Cloudflare). basePath is only used for the
+// GitHub Pages mirror; the indexable site lives at the apex subdomain.
+const siteUrl = 'https://machigai-salad.llll-ll.com'
+
+export const dynamic = 'force-static'
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+    },
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  }
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from 'next'
+
+const siteUrl = 'https://machigai-salad.llll-ll.com'
+
+export const dynamic = 'force-static'
+
+// Single-page app: one canonical entry is enough. lastModified uses the build
+// date (JST) already exposed via next.config so the sitemap stays in step with
+// each deploy without manual editing.
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: siteUrl,
+      lastModified: process.env.BUILD_DATE,
+      changeFrequency: 'monthly',
+      priority: 1,
+    },
+  ]
+}


### PR DESCRIPTION
## 概要
OGP は設定済みだが、SEOの基礎工事(robots/sitemap/構造化データ)が無く meta description も薄かったため整備。

「間違いサラダ」(固有名)は元々強いので、ここは**土台固め**。サイゼリヤ等の他社商標キーワードは意図的に入れていない（ブランド名 + ツール実用語のみ）。

## 変更
- **`app/robots.ts`** — `User-Agent: *` 全許可、`Sitemap`/`Host` を canonical(`https://machigai-salad.llll-ll.com`)で参照。`output: 'export'` で静的 `robots.txt` を生成
- **`app/sitemap.ts`** — 単一URLエントリ。`lastmod` は `BUILD_DATE`(JST)連動で毎デプロイ自動更新。静的 `sitemap.xml` を生成
- **`app/layout.tsx`**
  - `metadataBase` 追加（OGP絶対URL警告の解消）
  - `description` を検索スニペット向けに拡充（間違い探し/答え合わせ/ヒント/拡大/ブラウザで動作）。OGP・Twitter とも共有
  - `keywords` 追加
  - `SoftwareApplication` の JSON-LD（無料・Web・日本語）を埋め込み

## 検証
- `npm run build` 成功。`out/robots.txt`・`out/sitemap.xml` 生成を確認
- 静的 `out/index.html` に description / keywords / JSON-LD が焼かれていることを確認
- lint クリーン
- 既存テストの storage.test.ts 5件失敗は **main でも失敗する既存issue**（`Intl` の日付区切り `/`→`-` 環境差）。本PRの差分(layout/robots/sitemap)とは無関係

## デプロイ後やること
- 本番 `https://machigai-salad.llll-ll.com/robots.txt` ・ `/sitemap.xml` の実機確認
- Google Search Console に sitemap 登録（任意）

Closes #42