### PR TITLE
test: formatSaveDate テストを ISO日付形式に追従 (#44)

### DIFF
--- a/lib/storage.test.ts
+++ b/lib/storage.test.ts
@@ -4,31 +4,32 @@ import { formatSaveDate } from '@/lib/storage'
 /**
  * Characterization tests for formatSaveDate — a pure date formatter.
  * It builds a `new Date(iso)` and formats the *local-time* components as
- * `YYYY/MM/DD HH:mm` with zero-padded month/day/hour/minute (year is NOT
- * padded). The vitest config pins TZ=UTC so local-time getters here equal
- * the UTC wall-clock of the input, keeping these assertions deterministic.
+ * `YYYY-MM-DD HH:mm` (ISO-style, hyphen-separated) with zero-padded
+ * month/day/hour/minute (year is NOT padded). The vitest config pins TZ=UTC
+ * so local-time getters here equal the UTC wall-clock of the input, keeping
+ * these assertions deterministic.
  *
  * Production code is unchanged by this suite.
  */
 describe('formatSaveDate (TZ=UTC)', () => {
-  it('formats a UTC ISO timestamp as YYYY/MM/DD HH:mm', () => {
-    expect(formatSaveDate('2026-06-15T09:05:00.000Z')).toBe('2026/06/15 09:05')
+  it('formats a UTC ISO timestamp as YYYY-MM-DD HH:mm', () => {
+    expect(formatSaveDate('2026-06-15T09:05:00.000Z')).toBe('2026-06-15 09:05')
   })
 
   it('zero-pads single-digit month, day, hour and minute', () => {
-    expect(formatSaveDate('2026-01-02T03:04:00.000Z')).toBe('2026/01/02 03:04')
+    expect(formatSaveDate('2026-01-02T03:04:00.000Z')).toBe('2026-01-02 03:04')
   })
 
   it('uses two-digit hours for afternoon times (24-hour clock)', () => {
-    expect(formatSaveDate('2026-12-31T23:59:00.000Z')).toBe('2026/12/31 23:59')
+    expect(formatSaveDate('2026-12-31T23:59:00.000Z')).toBe('2026-12-31 23:59')
   })
 
   it('does not pad the year', () => {
     // Year 999 stays three digits — pin the quirk that only M/D/H/m are padded.
-    expect(formatSaveDate('0999-06-15T00:00:00.000Z')).toBe('999/06/15 00:00')
+    expect(formatSaveDate('0999-06-15T00:00:00.000Z')).toBe('999-06-15 00:00')
   })
 
   it('drops seconds and milliseconds', () => {
-    expect(formatSaveDate('2026-06-15T09:05:59.789Z')).toBe('2026/06/15 09:05')
+    expect(formatSaveDate('2026-06-15T09:05:59.789Z')).toBe('2026-06-15 09:05')
   })
 })


### PR DESCRIPTION
## 概要
`lib/storage.test.ts > formatSaveDate` の5件が main で失敗していたのを修正。

## 原因
- `773e5fe`(#38/#41) のテスト導入時、`formatSaveDate` は `/` 区切りだった
- `48ba995`「セーブ日時表示を /区切りから ISO (2025-06-15) 形式に変更」で**意図的に** `-` 区切りへ変更
- そのときテスト(`/` 期待)を追従し忘れ → 以後 main で常に5件失敗

→ 現行コード(ISO `-`)が正しい意図。**テストを `-` に追従**（コードは戻さない）。

## 変更
- 5アサーションを `2026/06/15` → `2026-06-15` 形式へ
- docstring の `YYYY/MM/DD` → `YYYY-MM-DD`

## 検証
- `npm test` → 24/24 全通過

Closes #44