### PR TITLE
feat: PWA更新検知時のoverlay+自動reloadをmypace方式で実装

### DIFF
--- a/app/(en)/layout.tsx
+++ b/app/(en)/layout.tsx
@@ -26,8 +26,8 @@ export default function EnRootLayout({ children }: Readonly<{ children: React.Re
         <I18nProvider forcedLang="en">
           {children}
           <ToastContainer />
+          <ServiceWorkerRegister />
         </I18nProvider>
-        <ServiceWorkerRegister />
       </body>
     </html>
   )

--- a/app/(ja)/layout.tsx
+++ b/app/(ja)/layout.tsx
@@ -27,8 +27,8 @@ export default function JaRootLayout({ children }: Readonly<{ children: React.Re
         <I18nProvider>
           {children}
           <ToastContainer />
+          <ServiceWorkerRegister />
         </I18nProvider>
-        <ServiceWorkerRegister />
       </body>
     </html>
   )

--- a/components/ImageProcessor.tsx
+++ b/components/ImageProcessor.tsx
@@ -4,6 +4,7 @@ import { useState, useRef, useEffect, useCallback, useMemo } from 'react'
 import type { Point, CornerOffsets } from '@/types'
 import { useOpenCV } from '@/hooks'
 import { useI18n } from '@/lib/i18n'
+import { setAppBusy } from '@/lib/appBusy'
 import {
   getImageSize,
   resizeImage,
@@ -70,6 +71,18 @@ export default function ImageProcessor() {
     return () => {
       cancelled = true
     }
+  }, [])
+
+  // Report the "is the user mid-task" flag to the global PWA update gate.
+  // Everything past the upload screen (corner adjustment, comparison,
+  // GIF/video export, save) is unsaved work that a forced reload would wipe.
+  useEffect(() => {
+    setAppBusy(phase !== 'upload')
+  }, [phase])
+
+  // Always clear the busy flag if this component ever unmounts.
+  useEffect(() => {
+    return () => setAppBusy(false)
   }, [])
 
   // Revoke any outstanding loaded object URLs on unmount

--- a/components/ServiceWorkerRegister.test.ts
+++ b/components/ServiceWorkerRegister.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+
+/**
+ * ServiceWorkerRegister.tsx is a 'use client' React component and can't be
+ * rendered under vitest's node environment (vitest.config.ts is node-env,
+ * *.test.ts only — no jsdom/RTL in this repo). So instead of exercising the
+ * component, this parses its source with the TypeScript compiler API and
+ * asserts the *shape* of the registration effect directly: a structural
+ * regression guard for a bug found in independent review of #51.
+ *
+ * Regression: the SW-registration useEffect used to depend on `[t]`
+ * (lib/i18n.tsx's translator, a useCallback keyed on `lang`). Because `t`'s
+ * reference changes whenever `lang` changes — e.g. the client-side language
+ * auto-detect effect flipping 'ja' -> 'en' shortly after mount on `/` (any
+ * non-forcedLang route) — that dependency re-ran the whole effect. Its
+ * cleanup only sets `cancelled = true`; it never removed the `updatefound`
+ * listener it had attached to the registration. So a real update landing
+ * later fired *two* listeners (one stale, one live) synchronously off the
+ * same `statechange` event, and the module-level `applying` guard's
+ * interaction with the stale listener's `cancelled` check meant the update
+ * could be silently dropped — no error, no overlay, no reload. See
+ * ServiceWorkerRegister.tsx's comment above the registration effect for the
+ * full trace.
+ *
+ * The fix: the registration effect must run exactly once (`[]`), and the
+ * current translation is read through a ref (`tRef.current`) instead of a
+ * dependency, so language changes never re-trigger SW registration.
+ */
+
+function loadSource() {
+  const path = fileURLToPath(new URL('./ServiceWorkerRegister.tsx', import.meta.url))
+  const text = readFileSync(path, 'utf-8')
+  const sourceFile = ts.createSourceFile(
+    path,
+    text,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TSX
+  )
+  return { text, sourceFile }
+}
+
+/** Finds every `useEffect(fn, deps)` call in the source. */
+function findUseEffectCalls(sourceFile: ts.SourceFile): ts.CallExpression[] {
+  const calls: ts.CallExpression[] = []
+  const visit = (node: ts.Node) => {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === 'useEffect'
+    ) {
+      calls.push(node)
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  return calls
+}
+
+/** The registration effect is identified by its body calling `.register(` on the SW container. */
+function isRegistrationEffect(call: ts.CallExpression, text: string): boolean {
+  const [effectFn] = call.arguments
+  if (!effectFn) return false
+  const body = text.slice(effectFn.getStart(), effectFn.getEnd())
+  return body.includes('serviceWorker') && body.includes('.register(')
+}
+
+describe('ServiceWorkerRegister.tsx — SW registration effect shape (regression: #51 t-dependency)', () => {
+  it('has exactly one useEffect that registers the service worker', () => {
+    const { text, sourceFile } = loadSource()
+    const registrationEffects = findUseEffectCalls(sourceFile).filter((call) =>
+      isRegistrationEffect(call, text)
+    )
+    expect(registrationEffects).toHaveLength(1)
+  })
+
+  it('the registration effect has an empty dependency array (must run exactly once per page load)', () => {
+    const { text, sourceFile } = loadSource()
+    const [registrationEffect] = findUseEffectCalls(sourceFile).filter((call) =>
+      isRegistrationEffect(call, text)
+    )
+    expect(registrationEffect).toBeDefined()
+
+    const depsArg = registrationEffect.arguments[1]
+    expect(depsArg).toBeDefined()
+    expect(depsArg && ts.isArrayLiteralExpression(depsArg)).toBe(true)
+    if (depsArg && ts.isArrayLiteralExpression(depsArg)) {
+      // Regression guard: must be `[]`, not `[t]` (or anything else) — a
+      // non-empty deps array here re-runs SW registration/listener setup
+      // whenever any dependency's reference changes, which silently drops
+      // in-flight update detection (see file header comment above).
+      expect(depsArg.elements.length).toBe(0)
+    }
+  })
+
+  it('the registration effect reads the translator via tRef.current(...), not a bare t(...) call', () => {
+    const { text, sourceFile } = loadSource()
+    const [registrationEffect] = findUseEffectCalls(sourceFile).filter((call) =>
+      isRegistrationEffect(call, text)
+    )
+    const [effectFn] = registrationEffect.arguments
+    const body = text.slice(effectFn.getStart(), effectFn.getEnd())
+
+    expect(body).toContain("tRef.current('pwaUpdateRestarting')")
+    // A bare `t(` call (not preceded by `.`) would mean `t` — not `tRef` —
+    // is captured directly in this closure, which is exactly what made the
+    // effect need `[t]` in the regression this test guards against.
+    expect(body).not.toMatch(/[^.]\bt\(/)
+  })
+
+  it('tRef is kept in sync with the latest t via its own single-purpose effect', () => {
+    const { text } = loadSource()
+    expect(text).toMatch(/const tRef = useRef\(t\)/)
+    expect(text).toMatch(/tRef\.current = t\s*\n\s*}, \[t\]\)/)
+  })
+})

--- a/components/ServiceWorkerRegister.tsx
+++ b/components/ServiceWorkerRegister.tsx
@@ -10,6 +10,18 @@ const COOLDOWN_MS = 10000 // 10 seconds cooldown after an update reload
 const OVERLAY_DELAY_MS = 1500 // time the overlay is visible before triggering skipWaiting
 const CONTROLLERCHANGE_FALLBACK_MS = 2000 // reload anyway if controllerchange never fires
 
+// Module-level (not per-render) guard against concurrent applyUpdate() runs.
+// `updatefound`/`statechange` can fire more than once for the same update
+// (e.g. the effect re-registering listeners across re-renders, or the
+// browser re-checking), and without this a second call could race the first
+// while it's awaiting waitUntilIdle() — before the cooldown timestamp below
+// is written — producing a duplicate overlay, duplicate SKIP_WAITING
+// postMessage, duplicate controllerchange listener, and duplicate reload
+// timers. Intentionally left `true` on the success path: a reload is about
+// to blow away this module's state anyway. It's only reset on the
+// `cancelled` bail-out, which does *not* reload.
+let applying = false
+
 function shouldSkipUpdate(): boolean {
   const lastUpdate = sessionStorage.getItem(SW_UPDATE_KEY)
   if (!lastUpdate) return false
@@ -60,17 +72,24 @@ export default function ServiceWorkerRegister() {
     // `registration.waiting` (i.e. this is a real update, not the first
     // install — see the `navigator.serviceWorker.controller` check below).
     const applyUpdate = async (registration: ServiceWorkerRegistration) => {
+      if (applying) return
+
       if (shouldSkipUpdate()) {
         console.info('SW update skipped (cooldown)')
         return
       }
+
+      applying = true
 
       // Defer while the user is mid-task (corner adjustment / comparison /
       // GIF-video export / save) — a forced reload here would wipe unsaved
       // work. The overlay below also blocks further interaction once shown,
       // so there's no need to re-check busy after this point.
       await waitUntilIdle()
-      if (cancelled) return
+      if (cancelled) {
+        applying = false
+        return
+      }
 
       console.info('New version available, reloading...')
       showUpdateOverlay(t('pwaUpdateRestarting'))

--- a/components/ServiceWorkerRegister.tsx
+++ b/components/ServiceWorkerRegister.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useI18n } from '@/lib/i18n'
 import { isAppBusy, waitUntilIdle } from '@/lib/appBusy'
 import {
@@ -69,6 +69,48 @@ function showUpdateOverlay(message: string) {
 export default function ServiceWorkerRegister() {
   const { t } = useI18n()
 
+  // `t` is a useCallback keyed on `lang` (see lib/i18n.tsx) — its reference
+  // changes whenever `lang` changes, e.g. the auto-detect effect flipping
+  // 'ja' -> 'en' shortly after mount on the `/` (non-forcedLang) route. The
+  // registration effect below must run exactly once per page load (see its
+  // own comment for why depending on `t` there caused a silent update-drop
+  // regression), so the current translator is threaded through a ref
+  // instead of a dependency, and read via `tRef.current` at the one call
+  // site that needs it (showUpdateOverlay).
+  const tRef = useRef(t)
+  useEffect(() => {
+    tRef.current = t
+  }, [t])
+
+  // This effect must register the SW and attach its `updatefound` listener
+  // exactly once per page load — hence the `[]` dependency array below.
+  //
+  // Regression (found in independent review of #51): this effect used to
+  // depend on `[t]` so showUpdateOverlay could read the current
+  // translation. But `t` (lib/i18n.tsx) is a useCallback keyed on `lang`,
+  // so its reference changes whenever `lang` changes — e.g. the
+  // client-side language auto-detect effect flipping 'ja' -> 'en' shortly
+  // after mount on `/` (any non-forcedLang route, for a browser without
+  // 'ja' in navigator.languages). That reference change re-ran this
+  // effect. The cleanup below only sets `cancelled = true` — it never
+  // called `registration.removeEventListener('updatefound', ...)` — so the
+  // *first* (stale) run's listener stayed attached alongside the second
+  // (live) run's listener, both on the same registration.
+  //
+  // When a real update later reached `installed`, both `watchInstallingWorker`
+  // listeners fired synchronously for the same `statechange` event. The
+  // module-level `applying` flag (see above) only guards against a
+  // *second concurrent* run — it doesn't help here, because whichever
+  // listener acquired `applying` first could be the *stale* (cancelled)
+  // one: it sets `applying = true` synchronously, the live listener's call
+  // synchronously no-ops via `if (applying) return`, and then the stale
+  // listener resumes after `await waitUntilIdle()`, sees
+  // `cancelled === true`, resets `applying = false`, and bails — with no
+  // one left to retry. Net effect: the update was silently dropped, with
+  // no error and no overlay, defeating the mount-time detection and
+  // busy-regate work this file exists for. This file has no jsdom/RTL test
+  // (vitest.config.ts is node-env, *.test.ts only) — see
+  // ServiceWorkerRegister.test.ts for a source-shape regression guard.
   useEffect(() => {
     if (!('serviceWorker' in navigator)) return
 
@@ -98,7 +140,7 @@ export default function ServiceWorkerRegister() {
       }
 
       console.info('New version available, reloading...')
-      showUpdateOverlay(t('pwaUpdateRestarting'))
+      showUpdateOverlay(tRef.current('pwaUpdateRestarting'))
       sessionStorage.setItem(SW_UPDATE_KEY, Date.now().toString())
 
       // The overlay covers the screen, but that only blocks pointer-driven
@@ -164,7 +206,7 @@ export default function ServiceWorkerRegister() {
     return () => {
       cancelled = true
     }
-  }, [t])
+  }, [])
 
   return null
 }

--- a/components/ServiceWorkerRegister.tsx
+++ b/components/ServiceWorkerRegister.tsx
@@ -1,15 +1,123 @@
 'use client'
 
 import { useEffect } from 'react'
+import { useI18n } from '@/lib/i18n'
+import { waitUntilIdle } from '@/lib/appBusy'
+
+// Prevent SW update loop using timestamp (mirrors mypace's PWA update flow)
+const SW_UPDATE_KEY = 'sw-update-time'
+const COOLDOWN_MS = 10000 // 10 seconds cooldown after an update reload
+const OVERLAY_DELAY_MS = 1500 // time the overlay is visible before triggering skipWaiting
+const CONTROLLERCHANGE_FALLBACK_MS = 2000 // reload anyway if controllerchange never fires
+
+function shouldSkipUpdate(): boolean {
+  const lastUpdate = sessionStorage.getItem(SW_UPDATE_KEY)
+  if (!lastUpdate) return false
+  const elapsed = Date.now() - parseInt(lastUpdate, 10)
+  return elapsed < COOLDOWN_MS
+}
+
+function showUpdateOverlay(message: string) {
+  const overlay = document.createElement('div')
+  overlay.style.cssText = `
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(60, 36, 21, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 99999;
+  `
+
+  const messageEl = document.createElement('div')
+  messageEl.style.cssText = `
+    color: #fff8e7;
+    font-size: 0.9rem;
+    text-align: center;
+    padding: 1.5rem 2rem;
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 12px;
+    backdrop-filter: blur(10px);
+  `
+  messageEl.textContent = message
+
+  overlay.appendChild(messageEl)
+  document.body.appendChild(overlay)
+}
 
 export default function ServiceWorkerRegister() {
+  const { t } = useI18n()
+
   useEffect(() => {
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js', { scope: '/' }).catch((error) => {
+    if (!('serviceWorker' in navigator)) return
+
+    let cancelled = false
+
+    // Called once the new worker has finished installing and is sitting in
+    // `registration.waiting` (i.e. this is a real update, not the first
+    // install — see the `navigator.serviceWorker.controller` check below).
+    const applyUpdate = async (registration: ServiceWorkerRegistration) => {
+      if (shouldSkipUpdate()) {
+        console.info('SW update skipped (cooldown)')
+        return
+      }
+
+      // Defer while the user is mid-task (corner adjustment / comparison /
+      // GIF-video export / save) — a forced reload here would wipe unsaved
+      // work. The overlay below also blocks further interaction once shown,
+      // so there's no need to re-check busy after this point.
+      await waitUntilIdle()
+      if (cancelled) return
+
+      console.info('New version available, reloading...')
+      showUpdateOverlay(t('pwaUpdateRestarting'))
+      sessionStorage.setItem(SW_UPDATE_KEY, Date.now().toString())
+
+      // Set up the listener before triggering the switch-over.
+      navigator.serviceWorker.addEventListener('controllerchange', () => {
+        window.location.reload()
+      })
+
+      setTimeout(() => {
+        registration.waiting?.postMessage({ type: 'SKIP_WAITING' })
+        // Fallback: if controllerchange doesn't fire, reload anyway.
+        setTimeout(() => {
+          window.location.reload()
+        }, CONTROLLERCHANGE_FALLBACK_MS)
+      }, OVERLAY_DELAY_MS)
+    }
+
+    navigator.serviceWorker
+      .register('/sw.js', { scope: '/' })
+      .then((registration) => {
+        // Check for updates on registration.
+        registration.update().catch((error) => {
+          console.info('SW update check skipped:', error?.message || 'offline')
+        })
+
+        registration.addEventListener('updatefound', () => {
+          const newWorker = registration.installing
+          if (!newWorker) return
+          newWorker.addEventListener('statechange', () => {
+            // `installed` + an existing controller means this is an update
+            // (not the page's first-ever SW install).
+            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
+              applyUpdate(registration)
+            }
+          })
+        })
+      })
+      .catch((error) => {
         console.error('Service Worker registration failed:', error)
       })
+
+    return () => {
+      cancelled = true
     }
-  }, [])
+  }, [t])
 
   return null
 }

--- a/components/ServiceWorkerRegister.tsx
+++ b/components/ServiceWorkerRegister.tsx
@@ -2,7 +2,13 @@
 
 import { useEffect } from 'react'
 import { useI18n } from '@/lib/i18n'
-import { waitUntilIdle } from '@/lib/appBusy'
+import { isAppBusy, waitUntilIdle } from '@/lib/appBusy'
+import {
+  detectExistingUpdate,
+  watchInstallingWorker,
+  makeIdleGatedOnce,
+  type WorkerLike,
+} from '@/lib/swUpdateDetection'
 
 // Prevent SW update loop using timestamp (mirrors mypace's PWA update flow)
 const SW_UPDATE_KEY = 'sw-update-time'
@@ -67,11 +73,12 @@ export default function ServiceWorkerRegister() {
     if (!('serviceWorker' in navigator)) return
 
     let cancelled = false
+    const hasController = () => Boolean(navigator.serviceWorker.controller)
 
-    // Called once the new worker has finished installing and is sitting in
-    // `registration.waiting` (i.e. this is a real update, not the first
-    // install — see the `navigator.serviceWorker.controller` check below).
-    const applyUpdate = async (registration: ServiceWorkerRegistration) => {
+    // Called once a new worker has finished installing and is sitting in
+    // `waiting` (i.e. this is a real update, not the first install — see the
+    // `hasController` check at each call site below).
+    const applyUpdate = async (worker: WorkerLike) => {
       if (applying) return
 
       if (shouldSkipUpdate()) {
@@ -83,8 +90,7 @@ export default function ServiceWorkerRegister() {
 
       // Defer while the user is mid-task (corner adjustment / comparison /
       // GIF-video export / save) — a forced reload here would wipe unsaved
-      // work. The overlay below also blocks further interaction once shown,
-      // so there's no need to re-check busy after this point.
+      // work.
       await waitUntilIdle()
       if (cancelled) {
         applying = false
@@ -95,23 +101,51 @@ export default function ServiceWorkerRegister() {
       showUpdateOverlay(t('pwaUpdateRestarting'))
       sessionStorage.setItem(SW_UPDATE_KEY, Date.now().toString())
 
+      // The overlay covers the screen, but that only blocks pointer-driven
+      // interaction — it doesn't blur focus or trap keyboard input, so a
+      // control that was already focused before the overlay appeared can
+      // still be activated (e.g. Enter/Space), and any async work already
+      // in flight keeps running regardless of the overlay. So busy state can
+      // still flip back to true during the pre-delay/fallback wait below.
+      // makeIdleGatedOnce re-checks busy right before each point that would
+      // actually reload/postMessage, and if busy, waits for the next idle
+      // transition and retries instead of forcing it through — it also
+      // guards against controllerchange and the fallback timer both firing
+      // the reload.
+      const reloadIfIdleElseDefer = makeIdleGatedOnce({
+        isBusy: isAppBusy,
+        waitUntilIdle,
+        run: () => window.location.reload(),
+      })
+
       // Set up the listener before triggering the switch-over.
-      navigator.serviceWorker.addEventListener('controllerchange', () => {
-        window.location.reload()
+      navigator.serviceWorker.addEventListener('controllerchange', reloadIfIdleElseDefer, {
+        once: true,
       })
 
       setTimeout(() => {
-        registration.waiting?.postMessage({ type: 'SKIP_WAITING' })
-        // Fallback: if controllerchange doesn't fire, reload anyway.
-        setTimeout(() => {
-          window.location.reload()
-        }, CONTROLLERCHANGE_FALLBACK_MS)
+        const sendSkipWaiting = makeIdleGatedOnce({
+          isBusy: isAppBusy,
+          waitUntilIdle,
+          run: () => {
+            worker.postMessage({ type: 'SKIP_WAITING' })
+            // Fallback: if controllerchange doesn't fire, reload anyway.
+            setTimeout(reloadIfIdleElseDefer, CONTROLLERCHANGE_FALLBACK_MS)
+          },
+        })
+        sendSkipWaiting()
       }, OVERLAY_DELAY_MS)
     }
 
     navigator.serviceWorker
       .register('/sw.js', { scope: '/' })
       .then((registration) => {
+        // Catch an update that already finished installing (`waiting`) or
+        // is mid-install (`installing`) *before* this effect ran — see
+        // detectExistingUpdate's doc comment for why this is a normal
+        // post-deploy-reload timing, not just a rare edge case.
+        detectExistingUpdate(registration, hasController, (worker) => applyUpdate(worker))
+
         // Check for updates on registration.
         registration.update().catch((error) => {
           console.info('SW update check skipped:', error?.message || 'offline')
@@ -120,13 +154,7 @@ export default function ServiceWorkerRegister() {
         registration.addEventListener('updatefound', () => {
           const newWorker = registration.installing
           if (!newWorker) return
-          newWorker.addEventListener('statechange', () => {
-            // `installed` + an existing controller means this is an update
-            // (not the page's first-ever SW install).
-            if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-              applyUpdate(registration)
-            }
-          })
+          watchInstallingWorker(newWorker, hasController, (worker) => applyUpdate(worker))
         })
       })
       .catch((error) => {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -44,20 +44,41 @@
 ### PWA更新方針（mypace方式）
 
 手書き Service Worker（`public/sw.js`）と `components/ServiceWorkerRegister.tsx` が連携し、
-新バージョン検知後に自動で安全に切り替える。
+新バージョン検知後に自動で安全に切り替える。検知・busyゲートのロジック本体は
+`lib/swUpdateDetection.ts`（DOM非依存の純粋関数、vitest node環境でテスト可能）に切り出し、
+`ServiceWorkerRegister.tsx` はそれを配線するだけの薄いレイヤーにしている。
 
 - `sw.js` の `install` では `self.skipWaiting()` を**呼ばない**。既存タブが古い SW に
   制御されている「更新」ケースでは新 SW は `waiting` のまま待機する（初回インストール時は
   制御元がないため従来どおり即activateされる）
-- クライアント側 (`ServiceWorkerRegister`) が `updatefound` → 新 worker の `statechange`
-  で `installed` かつ `navigator.serviceWorker.controller` あり（=更新）を検知
+- 更新検知は2経路。両方とも `lib/swUpdateDetection.ts` の関数を使う
+  - **mount時にすでに`waiting`/`installing`のSWがある場合**: `detectExistingUpdate()` が
+    `registration.waiting`/`registration.installing` を直接チェックする。ブラウザは
+    ナビゲーション時に自前でSW更新チェックを行うため、React hydration→useEffect実行より
+    前に更新が完了しているケースは通常のデプロイ後リロードで普通に起こる
+    （`updatefound` は新規installing開始時にのみ発火し、すでにそれを過ぎたworkerには
+    再発火しないため、`updatefound` 待ちだけでは検知漏れになる）
+  - **mount後に新たな更新が来た場合**: `updatefound` → 新 worker の `statechange` で
+    `installed` かつ `navigator.serviceWorker.controller` あり（=更新）を
+    `watchInstallingWorker()` が検知
 - 検知後、`lib/appBusy.ts` の `waitUntilIdle()` でユーザーが作業中でないか確認してから
   overlay を表示（`pwaUpdateRestarting` の ja/en 文言）。作業中（`ImageProcessor` の
   `phase !== 'upload'`：角調整・比較・GIF/動画生成・保存）の間は reload しない
+- overlay 表示〜実際の reload の間も、`makeIdleGatedOnce()` で busy を3箇所
+  （postMessage送信直前・`controllerchange` ハンドラ内・fallbackタイマー内）再チェックする。
+  overlay はポインタ操作こそ塞ぐが、フォーカス済み要素へのキー入力や既に走っている非同期処理
+  までは止めないため、overlay表示後に作業が再開されるケースがある
 - overlay 表示後、`registration.waiting.postMessage({ type: 'SKIP_WAITING' })` で
   SW に `self.skipWaiting()` を実行させ、`controllerchange` を待って `location.reload()`
   （`controllerchange` が来ない場合は2秒でフォールバック reload）
 - `sessionStorage` に更新時刻を記録し、10秒以内の再更新はスキップ（reload ループ防止）
+- SW登録・リスナー設定用の `useEffect` は依存配列 `[]` で**必ず一度だけ**実行する。
+  overlay文言に使う `t`（`useI18n()`）は `useRef` 経由（`tRef.current(...)`）で参照し、
+  effectの依存には含めない。`t` は `lang` が変わるたびに参照が変わる
+  （`/` route の言語auto-detectで `'ja'→'en'` に切り替わる等）ため、これをeffectの依存に
+  入れると登録処理が再実行され、cleanupが `updatefound` リスナーを外さないことと相まって
+  同一registrationに複数リスナーが残り、実更新時にモジュールレベル `applying` フラグの
+  奪い合いで更新がサイレントに握りつぶされる（#51で発生した実際のリグレッション）
 
 参考実装: mypace (`apps/web/src/main.tsx` の `registerSW`) と同じ overlay → skipWaiting →
 controllerchange → reload → cooldown の流れを、vite-plugin-pwa を使わない素の

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -41,6 +41,28 @@
 └─────────────────────────────────────┘
 ```
 
+### PWA更新方針（mypace方式）
+
+手書き Service Worker（`public/sw.js`）と `components/ServiceWorkerRegister.tsx` が連携し、
+新バージョン検知後に自動で安全に切り替える。
+
+- `sw.js` の `install` では `self.skipWaiting()` を**呼ばない**。既存タブが古い SW に
+  制御されている「更新」ケースでは新 SW は `waiting` のまま待機する（初回インストール時は
+  制御元がないため従来どおり即activateされる）
+- クライアント側 (`ServiceWorkerRegister`) が `updatefound` → 新 worker の `statechange`
+  で `installed` かつ `navigator.serviceWorker.controller` あり（=更新）を検知
+- 検知後、`lib/appBusy.ts` の `waitUntilIdle()` でユーザーが作業中でないか確認してから
+  overlay を表示（`pwaUpdateRestarting` の ja/en 文言）。作業中（`ImageProcessor` の
+  `phase !== 'upload'`：角調整・比較・GIF/動画生成・保存）の間は reload しない
+- overlay 表示後、`registration.waiting.postMessage({ type: 'SKIP_WAITING' })` で
+  SW に `self.skipWaiting()` を実行させ、`controllerchange` を待って `location.reload()`
+  （`controllerchange` が来ない場合は2秒でフォールバック reload）
+- `sessionStorage` に更新時刻を記録し、10秒以内の再更新はスキップ（reload ループ防止）
+
+参考実装: mypace (`apps/web/src/main.tsx` の `registerSW`) と同じ overlay → skipWaiting →
+controllerchange → reload → cooldown の流れを、vite-plugin-pwa を使わない素の
+`navigator.serviceWorker` API で再現している。
+
 ### ルーティングと多言語 (i18n)
 
 言語ごとに **別URL** を持ち、各ページが自分の `<html lang>` を静的に出力する。

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,21 @@
 
 ## [Unreleased]
 
+### 追加 ✨
+
+- **PWA更新検知時の自動再起動をmypace方式に揃える** (#51)
+  - `public/sw.js`: `install` での無条件 `self.skipWaiting()` を廃止し、`message` イベントで
+    `{ type: 'SKIP_WAITING' }` を受けたときだけ `skipWaiting()` するように変更（更新時のみ影響。
+    初回インストールは制御元が無いため従来どおり即activate）
+  - `components/ServiceWorkerRegister.tsx`: `updatefound` → 新workerの`statechange`で更新を検知し、
+    overlay表示 → `postMessage(SKIP_WAITING)` → `controllerchange` 待ち reload（fallback 2秒）→
+    `sessionStorage` cooldown（10秒）の流れを追加。overlay文言はja/en対応（`lib/i18n.tsx` の
+    `pwaUpdateRestarting`）
+  - `lib/appBusy.ts` を新設。`ImageProcessor` が角調整・比較・GIF/動画生成・保存などの作業中
+    （`phase !== 'upload'`）を通知し、作業中は reload を defer（`waitUntilIdle()`）してユーザーの
+    未保存作業を守る
+  - `ServiceWorkerRegister` を両 `layout.tsx` の `I18nProvider` 内に移動（`/en` の言語判定に必要）
+
 ### 修正 🐛
 
 - **比較・位置合わせ画面で右コーナーを外へドラッグするとページが右にずれる問題を修正** (#40)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,15 @@
     （`phase !== 'upload'`）を通知し、作業中は reload を defer（`waitUntilIdle()`）してユーザーの
     未保存作業を守る
   - `ServiceWorkerRegister` を両 `layout.tsx` の `I18nProvider` 内に移動（`/en` の言語判定に必要）
+  - 検知・busyゲートのロジックを `lib/swUpdateDetection.ts`（DOM非依存の純粋関数）に切り出し
+  - mount時にすでに`waiting`/`installing`のSWがある場合を`detectExistingUpdate()`で検知（`updatefound`
+    は既に過ぎたworkerには再発火しないため、更新検知漏れになっていた）
+  - overlay表示〜実reloadの間、`makeIdleGatedOnce()` でbusyを3箇所（postMessage送信直前・
+    `controllerchange`ハンドラ内・fallbackタイマー内）再チェック（overlayはポインタ操作のみ塞ぐため）
+  - SW登録用`useEffect`の依存配列を`[t]`から`[]`に修正。`t`（`useI18n()`）は`lang`変更のたびに
+    参照が変わり、それを依存に含めると登録・リスナー設定が再実行され、cleanupが`updatefound`
+    リスナーを外さないことと相まって更新がサイレントに握りつぶされるリグレッションがあった
+    （overlay文言は`tRef.current(...)`で参照）
 
 ### 修正 🐛
 

--- a/lib/appBusy.test.ts
+++ b/lib/appBusy.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest'
+
+/**
+ * appBusy holds module-singleton state (`busy` / `idleWaiters` — see its own
+ * doc comment). To keep tests independent of execution order, each test
+ * gets a fresh module instance via vi.resetModules() + a dynamic import
+ * instead of relying on the previous test's leftover state.
+ */
+async function freshAppBusy() {
+  vi.resetModules()
+  return import('@/lib/appBusy')
+}
+
+describe('appBusy', () => {
+  it('starts idle: isAppBusy() is false on a fresh module', async () => {
+    const { isAppBusy } = await freshAppBusy()
+    expect(isAppBusy()).toBe(false)
+  })
+
+  it('setAppBusy(true) makes isAppBusy() true', async () => {
+    const { setAppBusy, isAppBusy } = await freshAppBusy()
+    setAppBusy(true)
+    expect(isAppBusy()).toBe(true)
+  })
+
+  it('waitUntilIdle() resolves immediately while idle', async () => {
+    const { waitUntilIdle } = await freshAppBusy()
+    await expect(waitUntilIdle()).resolves.toBeUndefined()
+  })
+
+  it('waitUntilIdle() stays pending while busy', async () => {
+    const { setAppBusy, waitUntilIdle } = await freshAppBusy()
+    setAppBusy(true)
+    const result = await Promise.race([
+      waitUntilIdle().then(() => 'resolved'),
+      new Promise((resolve) => setTimeout(() => resolve('timeout'), 20)),
+    ])
+    expect(result).toBe('timeout')
+  })
+
+  it('setAppBusy(false) resolves a waiter that was pending while busy', async () => {
+    const { setAppBusy, waitUntilIdle } = await freshAppBusy()
+    setAppBusy(true)
+    const waiter = waitUntilIdle()
+    setAppBusy(false)
+    await expect(waiter).resolves.toBeUndefined()
+  })
+
+  it('setAppBusy(false) resolves every pending waiter, not just the first', async () => {
+    const { setAppBusy, waitUntilIdle } = await freshAppBusy()
+    setAppBusy(true)
+    const waiters = [waitUntilIdle(), waitUntilIdle(), waitUntilIdle()]
+    setAppBusy(false)
+    await expect(Promise.all(waiters)).resolves.toEqual([undefined, undefined, undefined])
+  })
+
+  it('re-calling setAppBusy(true) while already busy does not resolve pending waiters', async () => {
+    const { setAppBusy, waitUntilIdle } = await freshAppBusy()
+    setAppBusy(true)
+    const waiter = waitUntilIdle()
+    setAppBusy(true) // still busy — must be a no-op with respect to waiters
+    const result = await Promise.race([
+      waiter.then(() => 'resolved'),
+      new Promise((resolve) => setTimeout(() => resolve('timeout'), 20)),
+    ])
+    expect(result).toBe('timeout')
+  })
+
+  it('setAppBusy(false) while already idle is a no-op (no throw, stays idle)', async () => {
+    const { setAppBusy, isAppBusy } = await freshAppBusy()
+    expect(() => setAppBusy(false)).not.toThrow()
+    expect(isAppBusy()).toBe(false)
+  })
+
+  it('does not double-resolve a waiter across repeated setAppBusy(false) calls', async () => {
+    const { setAppBusy, waitUntilIdle } = await freshAppBusy()
+    setAppBusy(true)
+    const waiter = waitUntilIdle()
+    let resolveCount = 0
+    waiter.then(() => resolveCount++)
+
+    setAppBusy(false) // first idle transition — resolves the waiter once
+    await waiter
+
+    setAppBusy(false) // already idle — must not re-invoke the same waiter's resolve
+    setAppBusy(false)
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(resolveCount).toBe(1)
+  })
+})

--- a/lib/appBusy.ts
+++ b/lib/appBusy.ts
@@ -1,0 +1,33 @@
+/**
+ * Global "is the user in the middle of something" flag.
+ *
+ * ImageProcessor reports whether the multi-step photo flow (corner
+ * adjustment / comparison / GIF-video export / save) is active. The PWA
+ * update handler (ServiceWorkerRegister) reads this to defer the
+ * update-triggered reload until the user is back on the idle upload screen,
+ * so an in-progress edit is never wiped out by a forced reload.
+ */
+
+let busy = false
+let idleWaiters: Array<() => void> = []
+
+export function setAppBusy(next: boolean) {
+  busy = next
+  if (!busy && idleWaiters.length > 0) {
+    const toNotify = idleWaiters
+    idleWaiters = []
+    toNotify.forEach((resolve) => resolve())
+  }
+}
+
+export function isAppBusy(): boolean {
+  return busy
+}
+
+/** Resolves immediately if idle, otherwise resolves on the next transition to idle. */
+export function waitUntilIdle(): Promise<void> {
+  if (!busy) return Promise.resolve()
+  return new Promise((resolve) => {
+    idleWaiters.push(resolve)
+  })
+}

--- a/lib/i18n.tsx
+++ b/lib/i18n.tsx
@@ -206,6 +206,12 @@ const dict = {
 
   // Toast
   toastClose: { ja: '閉じる', en: 'Close' },
+
+  // PWA update overlay (ServiceWorkerRegister)
+  pwaUpdateRestarting: {
+    ja: '新しいバージョンがあります。再起動します...',
+    en: 'New version available. Restarting...',
+  },
 } as const
 
 type DictKey = keyof typeof dict

--- a/lib/sw.test.ts
+++ b/lib/sw.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import vm from 'node:vm'
+
+/**
+ * public/sw.js is a real Service Worker script — it references the SW
+ * global `self` (not `window`/`globalThis`) and isn't a module (no
+ * import/export), so it can't be imported directly even under vitest's
+ * node environment. This loads its source text into a vm sandbox with a
+ * minimal mock `self`/`caches`, capturing the listeners it registers via
+ * `self.addEventListener` so they can be invoked directly and asserted on.
+ * The real browser Cache/SW machinery is not exercised — only the
+ * skipWaiting-gating logic this PR touches.
+ */
+function loadServiceWorker() {
+  const swPath = fileURLToPath(new URL('../public/sw.js', import.meta.url))
+  const src = readFileSync(swPath, 'utf-8')
+
+  const listeners: Record<string, Array<(event: unknown) => void>> = {}
+  const skipWaiting = vi.fn()
+  const claim = vi.fn()
+  const cacheStub = {
+    addAll: vi.fn().mockResolvedValue(undefined),
+    put: vi.fn().mockResolvedValue(undefined),
+    match: vi.fn().mockResolvedValue(undefined),
+  }
+
+  const sandbox = {
+    self: {
+      addEventListener: (type: string, handler: (event: unknown) => void) => {
+        ;(listeners[type] ??= []).push(handler)
+      },
+      skipWaiting,
+      clients: { claim },
+    },
+    caches: {
+      open: vi.fn().mockResolvedValue(cacheStub),
+      keys: vi.fn().mockResolvedValue([]),
+      delete: vi.fn().mockResolvedValue(true),
+    },
+  }
+  vm.createContext(sandbox)
+  vm.runInContext(src, sandbox)
+
+  return { listeners, skipWaiting }
+}
+
+/** Fire all handlers registered for `type`, defaulting to a no-op event stub. */
+function fire(
+  listeners: Record<string, Array<(event: unknown) => void>>,
+  type: string,
+  event: unknown = { waitUntil: vi.fn() }
+) {
+  for (const handler of listeners[type] ?? []) handler(event)
+}
+
+describe('sw.js', () => {
+  it('does not call self.skipWaiting() during the install event (regression: was unconditional)', () => {
+    const { listeners, skipWaiting } = loadServiceWorker()
+    expect(listeners.install?.length).toBeGreaterThan(0)
+
+    fire(listeners, 'install')
+
+    expect(skipWaiting).not.toHaveBeenCalled()
+  })
+
+  it('calls self.skipWaiting() when it receives a message with type SKIP_WAITING', () => {
+    const { listeners, skipWaiting } = loadServiceWorker()
+    expect(listeners.message?.length).toBeGreaterThan(0)
+
+    fire(listeners, 'message', { data: { type: 'SKIP_WAITING' } })
+
+    expect(skipWaiting).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not call self.skipWaiting() for a message with a different type', () => {
+    const { listeners, skipWaiting } = loadServiceWorker()
+
+    fire(listeners, 'message', { data: { type: 'SOME_OTHER_MESSAGE' } })
+
+    expect(skipWaiting).not.toHaveBeenCalled()
+  })
+
+  it('does not throw when a message event has no data property', () => {
+    const { listeners } = loadServiceWorker()
+
+    expect(() => fire(listeners, 'message', {})).not.toThrow()
+  })
+})

--- a/lib/swUpdateDetection.test.ts
+++ b/lib/swUpdateDetection.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi } from 'vitest'
+import {
+  watchInstallingWorker,
+  detectExistingUpdate,
+  makeIdleGatedOnce,
+} from '@/lib/swUpdateDetection'
+
+/** Minimal ServiceWorker-shaped stub — captures the `statechange` handler so tests can fire it directly. */
+function makeWorker(initialState: string) {
+  const listeners: Array<() => void> = []
+  const worker = {
+    state: initialState,
+    addEventListener: vi.fn((type: string, handler: () => void) => {
+      if (type === 'statechange') listeners.push(handler)
+    }),
+    postMessage: vi.fn(),
+  }
+  return {
+    worker,
+    setState(state: string) {
+      worker.state = state
+    },
+    fireStatechange() {
+      for (const handler of listeners) handler()
+    },
+  }
+}
+
+describe('watchInstallingWorker', () => {
+  it('calls onInstalled when the worker reaches installed and a controller already exists', () => {
+    const { worker, setState, fireStatechange } = makeWorker('installing')
+    const onInstalled = vi.fn()
+
+    watchInstallingWorker(worker, () => true, onInstalled)
+    setState('installed')
+    fireStatechange()
+
+    expect(onInstalled).toHaveBeenCalledTimes(1)
+    expect(onInstalled).toHaveBeenCalledWith(worker)
+  })
+
+  it('does not call onInstalled while the worker is still installing (regression: #51 must 1)', () => {
+    const { worker, fireStatechange } = makeWorker('installing')
+    const onInstalled = vi.fn()
+
+    watchInstallingWorker(worker, () => true, onInstalled)
+    fireStatechange() // still 'installing' — no state change to 'installed' yet
+
+    expect(onInstalled).not.toHaveBeenCalled()
+  })
+
+  it('does not call onInstalled when installed but there is no existing controller (first install, not an update)', () => {
+    const { worker, setState, fireStatechange } = makeWorker('installing')
+    const onInstalled = vi.fn()
+
+    watchInstallingWorker(worker, () => false, onInstalled)
+    setState('installed')
+    fireStatechange()
+
+    expect(onInstalled).not.toHaveBeenCalled()
+  })
+
+  it('re-fires onInstalled correctly if statechange fires multiple times, only counting the installed transition', () => {
+    const { worker, setState, fireStatechange } = makeWorker('installing')
+    const onInstalled = vi.fn()
+
+    watchInstallingWorker(worker, () => true, onInstalled)
+    fireStatechange() // still installing
+    setState('installed')
+    fireStatechange() // now installed
+    fireStatechange() // installed again (e.g. duplicate event) — handler doesn't dedupe this itself
+
+    expect(onInstalled).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('detectExistingUpdate', () => {
+  it('regression (#51 must 1): calls onInstalled immediately for a worker already in `waiting` at mount time', () => {
+    const { worker } = makeWorker('installed')
+    const onInstalled = vi.fn()
+
+    detectExistingUpdate({ waiting: worker, installing: null }, () => true, onInstalled)
+
+    expect(onInstalled).toHaveBeenCalledTimes(1)
+    expect(onInstalled).toHaveBeenCalledWith(worker)
+  })
+
+  it('does not treat an already-waiting worker as an update when there is no existing controller (first install)', () => {
+    const { worker } = makeWorker('installed')
+    const onInstalled = vi.fn()
+
+    detectExistingUpdate({ waiting: worker, installing: null }, () => false, onInstalled)
+
+    expect(onInstalled).not.toHaveBeenCalled()
+  })
+
+  it('regression (#51 must 1): watches a worker already `installing` at mount time and detects it once installed', () => {
+    const { worker, setState, fireStatechange } = makeWorker('installing')
+    const onInstalled = vi.fn()
+
+    detectExistingUpdate({ waiting: null, installing: worker }, () => true, onInstalled)
+    expect(onInstalled).not.toHaveBeenCalled() // not installed yet — must watch, not fire immediately
+
+    setState('installed')
+    fireStatechange()
+
+    expect(onInstalled).toHaveBeenCalledTimes(1)
+    expect(onInstalled).toHaveBeenCalledWith(worker)
+  })
+
+  it('is a no-op when there is neither a waiting nor an installing worker', () => {
+    const onInstalled = vi.fn()
+    expect(() =>
+      detectExistingUpdate({ waiting: null, installing: null }, () => true, onInstalled)
+    ).not.toThrow()
+    expect(onInstalled).not.toHaveBeenCalled()
+  })
+})
+
+describe('makeIdleGatedOnce', () => {
+  it('runs immediately when not busy', () => {
+    const run = vi.fn()
+    const attempt = makeIdleGatedOnce({
+      isBusy: () => false,
+      waitUntilIdle: () => Promise.resolve(),
+      run,
+    })
+
+    attempt()
+
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('regression (#51 must 2): defers run() while busy and retries once idle, instead of forcing it through', async () => {
+    let busy = true
+    const run = vi.fn()
+    let releaseIdle: () => void = () => {}
+    const waitUntilIdle = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseIdle = resolve
+        })
+    )
+    const attempt = makeIdleGatedOnce({ isBusy: () => busy, waitUntilIdle, run })
+
+    attempt()
+    expect(run).not.toHaveBeenCalled()
+    expect(waitUntilIdle).toHaveBeenCalledTimes(1)
+
+    // User finishes their task — idle transition resolves the pending wait.
+    busy = false
+    releaseIdle()
+    await Promise.resolve() // flush the .then(attempt) microtask
+
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries through multiple busy periods before finally running once truly idle', async () => {
+    let busyCount = 2 // busy on the first two attempts, idle on the third
+    const run = vi.fn()
+    const releases: Array<() => void> = []
+    const waitUntilIdle = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releases.push(resolve)
+        })
+    )
+    const attempt = makeIdleGatedOnce({
+      isBusy: () => busyCount > 0,
+      waitUntilIdle,
+      run,
+    })
+
+    attempt()
+    expect(waitUntilIdle).toHaveBeenCalledTimes(1)
+
+    busyCount -= 1
+    releases[0]()
+    await Promise.resolve()
+    expect(run).not.toHaveBeenCalled()
+    expect(waitUntilIdle).toHaveBeenCalledTimes(2)
+
+    busyCount -= 1
+    releases[1]()
+    await Promise.resolve()
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('regression (#51 must 2): only runs once even if called multiple times (controllerchange + fallback timer racing)', () => {
+    const run = vi.fn()
+    const attempt = makeIdleGatedOnce({
+      isBusy: () => false,
+      waitUntilIdle: () => Promise.resolve(),
+      run,
+    })
+
+    attempt() // e.g. controllerchange fires
+    attempt() // e.g. fallback timer also fires
+
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not run again after a deferred idle-retry has already run once', async () => {
+    let busy = true
+    const run = vi.fn()
+    let releaseIdle: () => void = () => {}
+    const waitUntilIdle = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseIdle = resolve
+        })
+    )
+    const attempt = makeIdleGatedOnce({ isBusy: () => busy, waitUntilIdle, run })
+
+    attempt() // deferred (busy)
+    attempt() // called again before idle (e.g. a second trigger) — must not stack another wait
+
+    busy = false
+    releaseIdle()
+    await Promise.resolve()
+
+    expect(run).toHaveBeenCalledTimes(1)
+  })
+})

--- a/lib/swUpdateDetection.ts
+++ b/lib/swUpdateDetection.ts
@@ -1,0 +1,95 @@
+/**
+ * Pure, DOM-independent helpers for detecting a pending Service Worker
+ * update and gating the eventual reload on app-busy state.
+ *
+ * Pulled out of ServiceWorkerRegister.tsx (a 'use client' React component)
+ * specifically so this logic is unit-testable under vitest's node
+ * environment (see vitest.config.ts — node env, *.test.ts only, no DOM,
+ * no .tsx). It's exactly the logic independent QA flagged twice on #51:
+ *   1. a worker already `waiting`/`installing` at mount time (missed by only
+ *      listening for future `updatefound` events)
+ *   2. no busy re-check between the update overlay appearing and the actual
+ *      reload (postMessage / controllerchange / fallback timer)
+ */
+
+export type WorkerLike = Pick<ServiceWorker, 'state' | 'addEventListener' | 'postMessage'>
+
+// Declared against WorkerLike (not the real ServiceWorkerRegistration's
+// `ServiceWorker | null` properties) so a plain mock object satisfying
+// WorkerLike is directly assignable in tests, no `as unknown as` cast
+// needed. A real ServiceWorkerRegistration is still structurally assignable
+// here since a real ServiceWorker has everything WorkerLike requires.
+interface RegistrationLike {
+  readonly waiting: WorkerLike | null
+  readonly installing: WorkerLike | null
+}
+
+/**
+ * Watches a worker that's still installing and calls `onInstalled` once it
+ * reaches `installed` while a controller already exists (i.e. it's an
+ * update, not the page's first-ever SW install — a fresh install also
+ * passes through `installed`, but with no prior controller to hand off
+ * from).
+ */
+export function watchInstallingWorker(
+  worker: WorkerLike,
+  hasController: () => boolean,
+  onInstalled: (worker: WorkerLike) => void
+): void {
+  worker.addEventListener('statechange', () => {
+    if (worker.state === 'installed' && hasController()) {
+      onInstalled(worker)
+    }
+  })
+}
+
+/**
+ * Catches an update that already finished installing (`registration.waiting`)
+ * or is mid-install (`registration.installing`) *before* the caller attaches
+ * its `updatefound` listener.
+ *
+ * `updatefound` only fires at the moment a fresh install starts — it never
+ * re-fires for a worker that's already past that point by the time a
+ * listener is attached. The browser runs its own SW update check on
+ * navigation, and that check can complete (reaching `waiting`, or starting
+ * an `installing` in flight) before React hydration/useEffect gets this
+ * far — a normal timing on an ordinary post-deploy reload, not a rare edge
+ * case. Missing this means the update is silently dropped until some other
+ * trigger fires `updatefound`.
+ */
+export function detectExistingUpdate(
+  registration: RegistrationLike,
+  hasController: () => boolean,
+  onInstalled: (worker: WorkerLike) => void
+): void {
+  if (registration.waiting && hasController()) {
+    onInstalled(registration.waiting)
+  }
+  if (registration.installing) {
+    watchInstallingWorker(registration.installing, hasController, onInstalled)
+  }
+}
+
+/**
+ * Wraps `run` so it only fires once it's not busy, retrying on the next
+ * idle transition if called while busy, and never runs more than once total
+ * — safe to call from multiple triggers (e.g. both a `controllerchange`
+ * listener and a fallback timer racing to reload) without double-firing.
+ */
+export function makeIdleGatedOnce(deps: {
+  isBusy: () => boolean
+  waitUntilIdle: () => Promise<void>
+  run: () => void
+}): () => void {
+  let done = false
+  const attempt = () => {
+    if (done) return
+    if (deps.isBusy()) {
+      deps.waitUntilIdle().then(attempt)
+      return
+    }
+    done = true
+    deps.run()
+  }
+  return attempt
+}

--- a/public/sw.js
+++ b/public/sw.js
@@ -5,7 +5,22 @@ const PRECACHE_URLS = ['/', '/manifest.webmanifest']
 
 self.addEventListener('install', (event) => {
   event.waitUntil(caches.open(CACHE_NAME).then((cache) => cache.addAll(PRECACHE_URLS)))
-  self.skipWaiting()
+  // No unconditional self.skipWaiting() here: on an update (a previous SW is
+  // already controlling open tabs), this worker should sit in `waiting`
+  // until the client explicitly approves via postMessage (see below). This
+  // lets the client defer taking over until the user is safely idle instead
+  // of forcing a mid-task reload. First-time installs (no existing
+  // controller) still activate immediately regardless — skipWaiting() only
+  // affects the update case.
+})
+
+// Client-driven activation: the client (ServiceWorkerRegister) posts this
+// once it has confirmed the user isn't mid-task, so the new SW can take
+// over and the client can reload on the resulting controllerchange.
+self.addEventListener('message', (event) => {
+  if (event.data?.type === 'SKIP_WAITING') {
+    self.skipWaiting()
+  }
 })
 
 self.addEventListener('activate', (event) => {


### PR DESCRIPTION
## 関連 Issue
Refs #51（実機/build previewでの動作確認が完了するまでopenのまま）

## 変更内容
- `public/sw.js` の `skipWaiting` をmessage駆動に変更（初回インストールは従来通り自動、更新時のみクライアント承認を待つ）
- `lib/appBusy.ts`（新規）で作業中（撮影後の調整・比較・書き出し等）はreloadをdeferするゲートを追加
- `components/ServiceWorkerRegister.tsx` を overlay→postMessage→controllerchange reload→fallback→cooldown のフローに書き換え
- `/en` ルートでoverlay文言が正しく英語になるよう `ServiceWorkerRegister` の配置を修正
- QAレビュー指摘を反映: `applyUpdate` 多重発火防止フラグを追加
- テスト13件追加（既存24件+新規13件、37件全通過）

## 既知のギャップ
- `vitest.config.ts` が `environment: 'node'` 限定（"Pure-logic helpers only"）のため、`ServiceWorkerRegister.tsx` / `ImageProcessor.tsx` 本体（今回のQA修正=多重発火防止フラグを含む）はunitテスト化できていません。純粋ロジック（`appBusy.ts`, `sw.js`）はカバー済み
- 実ブラウザでのoverlay→SW切替→reloadの一連の流れは未検証（CLAUDE.mdルール1により実機確認が必要）